### PR TITLE
Rework iflag and bus reading logic

### DIFF
--- a/EDK.srcs/sim_1/new/tb_encoder.v
+++ b/EDK.srcs/sim_1/new/tb_encoder.v
@@ -2,21 +2,21 @@
 
 module tb_encoder;
 
-reg         Bus2IP_Clk;
-reg         Bus2IP_Reset;
+reg             Bus2IP_Clk;
+reg             Bus2IP_Reset;
 
-reg  [31:0] Bus2IP_Data;
-reg  [3:0]  Bus2IP_BE;
-reg  [1:0]  Bus2IP_RdCE;
-reg  [1:0]  Bus2IP_WrCE;
-wire [31:0] IP2Bus_Data;
-wire        IP2Bus_RdAck;
-wire        IP2Bus_WrAck;
-wire        IP2Bus_Error;
+reg  [0 : 31]   Bus2IP_Data;
+reg  [0 :  3]   Bus2IP_BE;
+reg  [0 :  1]   Bus2IP_RdCE;
+reg  [0 :  1]   Bus2IP_WrCE;
+wire [0 : 31]   IP2Bus_Data;
+wire            IP2Bus_RdAck;
+wire            IP2Bus_WrAck;
+wire            IP2Bus_Error;
 
-reg         encoder_a;
-reg         encoder_b;
-wire        irq;
+reg             encoder_a;
+reg             encoder_b;
+wire            irq;
 
 encoder_user_logic dut(
    //A PLB IPIF interfész portjai.
@@ -56,14 +56,14 @@ end
 endtask
 
 task BUS_WRITE;
-input [31:0] Data;
-input integer addr;
+input [0:31] Data;
+input integer register;
 begin
 @ (posedge Bus2IP_Clk);
 Bus2IP_Data <= Data;
-Bus2IP_WrCE <= (addr == 0) ? 2'b01 : 2'b10;
+Bus2IP_WrCE <= (register == 0) ? 2'b10 : 2'b01;
 @ (posedge Bus2IP_Clk);
-Bus2IP_Data <= 32'hXXXXXXXX;
+Bus2IP_Data <= 32'hZZZZZZZZ;
 Bus2IP_WrCE <= 2'b00;
 end
 endtask
@@ -71,7 +71,7 @@ endtask
 task BUS_READ_COUNTER;
 begin
 @ (posedge Bus2IP_Clk);
-Bus2IP_RdCE <= 2'b10;
+Bus2IP_RdCE <= 2'b01;
 @ (posedge Bus2IP_Clk);
 Bus2IP_RdCE <= 2'b00;
 end
@@ -86,7 +86,7 @@ Bus2IP_RdCE <= 0;
 
 #500 Bus2IP_Reset <= 0;
 
-#1000 BUS_WRITE({2'b10, 30'h0}, 0);
+#1000 BUS_WRITE({30'b0, 2'b01}, 0);
 
 #4_000_000;
 ROTATE_CLOCKWISE;

--- a/EDK.srcs/sources_1/new/encoder_user_logic.v
+++ b/EDK.srcs/sources_1/new/encoder_user_logic.v
@@ -56,12 +56,14 @@ output wire                        irq;
 //* A továbbiakban a Bus2IP_Data jel helyett használja a wr_data jelet.       *
 //*****************************************************************************
 reg     [C_SLV_DWIDTH-1:0] wr_data;
+reg     [C_SLV_DWIDTH-1:0] rd_data;
 integer                    i;
 
 always @(*)
-   for (i = 0; i < C_SLV_DWIDTH; i = i + 1)
+   for (i = 0; i < C_SLV_DWIDTH; i = i + 1) begin
       wr_data[i] <= Bus2IP_Data[C_SLV_DWIDTH-i-1];
-      
+	   IP2Bus_Data[i] <= rd_data[C_SLV_DWIDTH-i-1];
+   end
 
 //*****************************************************************************
 //* A nyugtázó- és hibajelek meghajtása.                                      *
@@ -135,18 +137,15 @@ end
 //* A megszakításkérõ jel elõállítása.                                        *
 //*****************************************************************************
 reg ie;
-reg iflag;
 
 always @ (posedge Bus2IP_Clk)
-   if (Bus2IP_WrCE[0]) begin
-      ie <= wr_data[0];
-      iflag <= wr_data[1];
+   if (Bus2IP_Reset)
+       ie <= 1'b0;
+   else if (Bus2IP_WrCE[0]) begin
+       ie <= wr_data[0];
    end
 
-always @ (posedge Bus2IP_Clk)
-    if (counter != 0)
-        iflag <= 1'b1;
-
+wire iflag = (8'd0 == counter) ? 1'b0 : 1'b1;
 assign irq = ie && iflag;
 
 
@@ -154,14 +153,12 @@ assign irq = ie && iflag;
 //* Az olvasási adatbusz meghajtása.                                          *
 //*****************************************************************************
 
-always @ (posedge Bus2IP_Clk)
+always @ (*)
 if (Bus2IP_RdCE[0])
-    IP2Bus_Data <= {30'b0, iflag, ie};
-else if (Bus2IP_RdCE[1]) begin
-    IP2Bus_Data <= {24'b0, counter};
-    iflag <= 1'b0;
-end
+    rd_data <= {30'b0, iflag, ie};
+else if (Bus2IP_RdCE[1])
+    rd_data <= {{24{counter[7]}}, counter};
 else
-    IP2Bus_Data <= 32'b0;
+    rd_data <= 32'b0;
 
 endmodule

--- a/EDK.srcs/sources_1/new/encoder_user_logic.v
+++ b/EDK.srcs/sources_1/new/encoder_user_logic.v
@@ -33,11 +33,11 @@ parameter C_NUM_REG    = 2;
 //*****************************************************************************
 input  wire                        Bus2IP_Clk;
 input  wire                        Bus2IP_Reset;
-input  wire [C_SLV_DWIDTH-1 : 0]   Bus2IP_Data;
-input  wire [C_SLV_DWIDTH/8-1 : 0] Bus2IP_BE;
-input  wire [C_NUM_REG-1 : 0]      Bus2IP_RdCE;
-input  wire [C_NUM_REG-1 : 0]      Bus2IP_WrCE;
-output reg  [C_SLV_DWIDTH-1 : 0]   IP2Bus_Data;
+input  wire [0 : C_SLV_DWIDTH-1]   Bus2IP_Data;
+input  wire [0 : C_SLV_DWIDTH/8-1] Bus2IP_BE;
+input  wire [0 : C_NUM_REG-1]      Bus2IP_RdCE;
+input  wire [0 : C_NUM_REG-1]      Bus2IP_WrCE;
+output reg  [0 : C_SLV_DWIDTH-1]   IP2Bus_Data;
 output wire                        IP2Bus_RdAck;
 output wire                        IP2Bus_WrAck;
 output wire                        IP2Bus_Error;
@@ -141,9 +141,8 @@ reg ie;
 always @ (posedge Bus2IP_Clk)
    if (Bus2IP_Reset)
        ie <= 1'b0;
-   else if (Bus2IP_WrCE[0]) begin
+   else if (Bus2IP_WrCE[0])
        ie <= wr_data[0];
-   end
 
 wire iflag = (8'd0 == counter) ? 1'b0 : 1'b1;
 assign irq = ie && iflag;

--- a/tb_encoder_behav.wcfg
+++ b/tb_encoder_behav.wcfg
@@ -11,15 +11,15 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="23101533100fs"></ZoomStartTime>
-      <ZoomEndTime time="23101605501fs"></ZoomEndTime>
-      <Cursor1Time time="23101530000fs"></Cursor1Time>
+      <ZoomStartTime time="0fs"></ZoomStartTime>
+      <ZoomEndTime time="36400000001fs"></ZoomEndTime>
+      <Cursor1Time time="30000000000fs"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
-      <NameColumnWidth column_width="209"></NameColumnWidth>
+      <NameColumnWidth column_width="205"></NameColumnWidth>
       <ValueColumnWidth column_width="66"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="8" />
+   <WVObjectSize size="10" />
    <wvobject type="group" fp_name="group53">
       <obj_property name="label">Bus2IP</obj_property>
       <obj_property name="DisplayName">label</obj_property>
@@ -44,6 +44,14 @@
          <obj_property name="ElementShortName">Bus2IP_Data[31:0]</obj_property>
          <obj_property name="ObjectShortName">Bus2IP_Data[31:0]</obj_property>
       </wvobject>
+   </wvobject>
+   <wvobject type="logic" fp_name="/tb_encoder/encoder_a">
+      <obj_property name="ElementShortName">encoder_a</obj_property>
+      <obj_property name="ObjectShortName">encoder_a</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/tb_encoder/encoder_b">
+      <obj_property name="ElementShortName">encoder_b</obj_property>
+      <obj_property name="ObjectShortName">encoder_b</obj_property>
    </wvobject>
    <wvobject type="logic" fp_name="/tb_encoder/dut/sample_clk">
       <obj_property name="ElementShortName">sample_clk</obj_property>


### PR DESCRIPTION
Ide másolom a levelet és beleírom, hogy miket javítottam:

 - az ie bitet illene resetelni (szimuláció szebb lesz) - KÉSZ
 - IP -> bus irányhoz is meg kell fordítani a biteket, ne közvetlenül a IP2Bus_Data vezetékre tegyétek ki a jeleket (nézz meg az lcd-nél -> rd_data) - KÉSZ
 - a buszon az adat egyszerre kell, hogy megjelenjen a visszaigazoló jellel (IP2Bus_RdAck), tehát vagy a busz meghajtása (most  IP2Bus_Data, de majd rd_data) legyen kombinációs hálózat (always @(*)), vagy a visszaigazoló jelet is késleltessétek. (Inkább az előbbit javaslom, utóbbi esetben mást is könnyű elrontani.) - KÉSZ

 - az iflag-gel két probléma is van: KÉSZ
    - két always blokkban próbáljátok írni, de ilyet nem lehet (az FPGA-ban ez egyetlen regiszter lesz, a két külön always blokk pedig két regisztert írna le). Furcsa, hogy a szimuláció engedte, szintetizálni már nem lehetne.
    - ráadásul nem is szükséges írásra resetelni, hanem a counter olvasásával kell, viszont ezt sem explicit módon. Amikor a counter-t kiolvastuk (és ezzel nullázzuk az értékét, amit meg is csináltatok) már nem kell megszakítást adni.
    - a legegyszerűbb így megvalósítani: assign iflag = (8'd0 == counter) ? 1'b0 : 1'b1; - ÍGY CSINÁLTAM MEG :)

 - az olvasási busz meghajtáskor hiányzik a counter előjel kiterjesztése (ha 32 bitesen olvassuk a buszt, akkor a felső 24 bit mindig 0 lesz, így mindig nemnegatív számot olvasunk vissza: 0...255) - KÉSZ

EZT NEM ÉRTEM:
 - a busz jeleinél megfordítottátok a bitsorrendet, ezt nem szabadott volna (oda is van írva), így nem fog működni szintéziskor

EBBE MEG NEM AKARTAM BELETÚRNI:
 - a busz jeleknél a szimulációban is használjatok fordított bitsorrendet ([0:31], [0:3], stb...)
